### PR TITLE
ci: switch to windows-2025 and ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2022, macos-14, ubuntu-22.04 ]
+        os: [windows-2025, macos-14, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     concurrency:
       group: build-${{ github.workflow }}-${{ matrix.os }}-${{ github.event.number || github.ref }}


### PR DESCRIPTION
This PR should target the `master` branch and addresses a sporadic issue on Windows runners involving an incompatibility between Visual Studio Code and the Clang version (see more details [here](https://github.com/actions/runner-images/issues/12435)).